### PR TITLE
Add plot_image option to map plots

### DIFF
--- a/figure_notebooks/figure3_channel_selection.ipynb
+++ b/figure_notebooks/figure3_channel_selection.ipynb
@@ -32,7 +32,7 @@
     "import matplotlib as mpl\n",
     "\n",
     "#%matplotlib widget\n",
-    "%matplotlib inline"
+    "%matplotlib notebook"
    ]
   },
   {
@@ -109,6 +109,15 @@
    "outputs": [],
    "source": [
     "template = templates[selected_unit]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = av.plot_amplitude_map(template, locations, plot_image=False, elec_size=15)"
    ]
   },
   {

--- a/tests/test_axon_velocity.py
+++ b/tests/test_axon_velocity.py
@@ -53,8 +53,11 @@ class TestExtractors(unittest.TestCase):
     def test_plotting(self):
         av.plot_template(self.template_bifurcation, self.locations_bifurcation)
         av.plot_peak_latency_map(self.template_bifurcation, self.locations_bifurcation, self.fs)
+        av.plot_peak_latency_map(self.template_bifurcation, self.locations_bifurcation, self.fs, plot_image=False)
         av.plot_amplitude_map(self.template_bifurcation, self.locations_bifurcation)
-        av.plot_peak_std_map(self.template_bifurcation, self.locations_bifurcation)
+        av.plot_amplitude_map(self.template_bifurcation, self.locations_bifurcation, plot_image=False)
+        av.plot_peak_std_map(self.template_bifurcation, self.locations_bifurcation, self.fs)
+        av.plot_peak_std_map(self.template_bifurcation, self.locations_bifurcation, self.fs, plot_image=False)
         av.plot_branch_velocities(self.gtr_bif.branches)
         av.plot_axon_summary(self.gtr_bif)
         av.plot_branch_velocities(self.gtr_bif.branches)


### PR DESCRIPTION
The `plot_image` option allows to render the map plots in two different ways:

- `plot_image=True`: the value of each electrode is interpolated and an image is obtained and plotted. It works very well with dense and *full* configurations
- `plot_image=False`: each electrode is rendered as a polygon and the color is its value. The `elec_size` option controls how large each electrode would be, and it can be adjusted to optimize the plotting